### PR TITLE
Fix file path sanitization when rendering FFMPEG args

### DIFF
--- a/src/converter/ffmpegService.ts
+++ b/src/converter/ffmpegService.ts
@@ -10,18 +10,20 @@ export class FFMPEGService {
 		private destinationDirectory: string,
 	) {}
 
-	private renderArgs = (args: string, ...params: string[]) => {
-		let i = 0;
-		return args.replace(/%s/g, () => params[i++]);
-	};
-
 	private splitArgs = (args: string) => args.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+
+	private renderAndSplitArgs = (args: string, ...params: string[]) => {
+		let i = 0;
+		return this.splitArgs(args).map((a) => a.replace(/%s/g, () => params[i++]));
+	};
 
 	exec = async (abortSignal: AbortSignal, sourceFilePath: string): Promise<void> => {
 		return new Promise((resolvePromise, reject) => {
 			const { name } = parse(sourceFilePath);
-			const args = this.splitArgs(
-				this.renderArgs(this.ffmpegArgs, resolve(sourceFilePath), join(resolve(this.destinationDirectory), name)),
+			const args = this.renderAndSplitArgs(
+				this.ffmpegArgs,
+				resolve(sourceFilePath),
+				join(resolve(this.destinationDirectory), name),
 			);
 			this.logger.debug("Launching ffmpeg process", { bin: this.ffmpegPath, args, sourceFilePath });
 			const subProcess = execa(this.ffmpegPath, args, { signal: abortSignal });


### PR DESCRIPTION
Thanks for this great project! I was having trouble converting files that had spaces or special characters in their name because the existing code was splitting the input and output locations into multiple arguments. This seems to fix it! Let me know if there are any issues with it!