### PR TITLE
Add text log format and improve json logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ Configure the container through environment variables. Here's a breakdown of wha
     <td>No (default: <code>3</code>)</td>
     <td>How many cycles the service will wait for new files to stay unchanged until conversion starts. See below for detailed info.</td>
   </tr>
+  <tr>
+    <td><code>LOG_LEVEL</code></td>
+    <td>No (default: <code>info</code>)</td>
+    <td>debug, info, warn, error or fatal</td>
+  </tr>
+  <tr>
+    <td><code>LOG_FORMAT</code></td>
+    <td>No (default: <code>json</code>)</td>
+    <td><code>json</code> or <code>text</code>. Whether to log to console or file in JSON or simple text.</td>
+  </tr>
+  <tr>
+    <td><code>LOG_DESTINATION</code></td>
+    <td>No (default: off)</td>
+    <td>Path to a logs directory. Example: <code>./logs</code>. When given, it will additionally write logs to files and rotates them daily.</td>
+  </tr>
 </table>
 
 ## 💼 How the Service Works

--- a/src/utils/applicationContext.ts
+++ b/src/utils/applicationContext.ts
@@ -1,15 +1,22 @@
 import { ConverterService, FFMPEGService } from "../converter";
 import { FileWatcherService } from "../watcher/fileWatcherService";
 import { Configuration } from "./configuration";
-import { createLogger } from "./logger";
+import { createLogger, type Logger } from "./logger";
 
 export class ApplicationContext {
-  private readonly rootLogger = createLogger({});
+  private readonly rootLogger: Logger;
   public readonly fileWatcherService: FileWatcherService;
   public readonly ffmpegService: FFMPEGService;
   public readonly converterService: ConverterService;
 
   constructor(private configuration: Configuration = new Configuration()) {
+    this.rootLogger = createLogger({
+      config: {
+        level: this.configuration.config.LOG_LEVEL,
+        format: this.configuration.config.LOG_FORMAT,
+        destination: this.configuration.config.LOG_DESTINATION,
+      },
+    });
     this.fileWatcherService = new FileWatcherService(
       this.rootLogger.child({ name: "FileWatcherService" }),
       this.configuration.config.SOURCE_DIRECTORY_PATH,

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,11 +1,16 @@
 import { config } from "dotenv";
 
-config();
+config({ quiet: true });
 
 import { z } from "zod";
 
 const environmentVariables = z.object({
   VERSION: z.string().default("develop"),
+
+  LOG_LEVEL: z.enum(["debug", "info", "warn", "error", "fatal"]).default("info"),
+  LOG_FORMAT: z.enum(["json", "text"]).default("json"),
+  LOG_DESTINATION: z.string().optional(),
+
   GLOB_PATTERNS: z.string().transform((s) => s.split(",")),
   SCAN_INTERVAL: z
     .string()
@@ -27,6 +32,8 @@ const environmentVariables = z.object({
 });
 
 type EnvironmentConfiguration = z.infer<typeof environmentVariables>;
+export type LogLevel = EnvironmentConfiguration["LOG_LEVEL"];
+export type LogFormat = EnvironmentConfiguration["LOG_FORMAT"];
 
 export class Configuration {
   constructor(public config: EnvironmentConfiguration = environmentVariables.parse(process.env)) {}


### PR DESCRIPTION
Improves the readability of logs.

**text**
```
❯ LOG_FORMAT=text pnpm dev

[2025-08-21T23:27:56.916Z] ConverterService info:       Starting converter service | {"version":"develop"}
[2025-08-21T23:27:56.994Z] ConverterService info:       This software uses libraries from the FFmpeg project under the LGPLv2.1 | {"ffmpegVersion":"7.1.1"}
[2025-08-21T23:27:56.995Z] FileWatcherService info:     Starting to poll for new files in source directory | {"sourceDirectory":"./data/input","patterns":["*.webm","*.mp4"]}
[2025-08-21T23:27:58.008Z] FileWatcherService debug:    Found 1 file | {"sourceDirectory":"./data/input","files":["example.webm"]}
[2025-08-21T23:27:58.009Z] FileWatcherService debug:    Caching new file | {"file":"data/input/example.webm"}
```

**json**

Keys are now sorted

```
❯ LOG_FORMAT=json pnpm dev

{"timestamp":"2025-08-21T23:24:55.585Z","level":"info","name":"ConverterService","message":"Starting converter service","version":"develop"}
{"timestamp":"2025-08-21T23:24:55.643Z","level":"info","name":"ConverterService","message":"This software uses libraries from the FFmpeg project under the LGPLv2.1","ffmpegVersion":"7.1.1"}
{"timestamp":"2025-08-21T23:24:55.643Z","level":"info","name":"FileWatcherService","message":"Starting to poll for new files in source directory","sourceDirectory":"./data/input","patterns":["*.webm","*.mp4"]}
{"timestamp":"2025-08-21T23:24:56.657Z","level":"debug","name":"FileWatcherService","message":"Found 1 file","sourceDirectory":"./data/input","files":["example.webm"]}
{"timestamp":"2025-08-21T23:24:56.658Z","level":"debug","name":"FileWatcherService","message":"Caching new file","file":"data/input/example.webm"}
```